### PR TITLE
Add new APIs to ExoMediaDrm

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DummyExoMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/DummyExoMediaDrm.java
@@ -156,4 +156,14 @@ public final class DummyExoMediaDrm implements ExoMediaDrm {
   public @C.CryptoType int getCryptoType() {
     return C.CRYPTO_TYPE_UNSUPPORTED;
   }
+
+  @Override
+  public void removeOfflineLicense(byte[] keySetId) {
+    // Do nothing
+  }
+
+  @Override
+  public List<byte[]> getOfflineLicenseKeySetIds() {
+    return null;
+  }
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ExoMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/ExoMediaDrm.java
@@ -575,4 +575,14 @@ public interface ExoMediaDrm {
    */
   @C.CryptoType
   int getCryptoType();
+
+  /**
+   * See {@link MediaDrm#removeOfflineLicense(byte[])}
+   */
+  void removeOfflineLicense(byte[] keySetId);
+
+  /**
+   * See {@link MediaDrm#getOfflineLicenseKeySetIds()}
+   */
+  List<byte[]> getOfflineLicenseKeySetIds();
 }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -26,6 +26,7 @@ import android.media.MediaDrmException;
 import android.media.NotProvisionedException;
 import android.media.UnsupportedSchemeException;
 import android.media.metrics.LogSessionId;
+import android.os.Build;
 import android.os.PersistableBundle;
 import android.text.TextUtils;
 import androidx.annotation.DoNotInline;
@@ -46,6 +47,7 @@ import com.google.common.base.Charsets;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -378,6 +380,21 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   @Override
   public @C.CryptoType int getCryptoType() {
     return C.CRYPTO_TYPE_FRAMEWORK;
+  }
+
+  @Override
+  public void removeOfflineLicense(byte[] keySetId) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      mediaDrm.removeOfflineLicense(keySetId);
+    }
+  }
+
+  @Override
+  public List<byte[]> getOfflineLicenseKeySetIds() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      return mediaDrm.getOfflineLicenseKeySetIds();
+    }
+    return Collections.emptyList();
   }
 
   private static SchemeData getSchemeData(UUID uuid, List<SchemeData> schemeDatas) {

--- a/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeExoMediaDrm.java
+++ b/libraries/test_utils/src/main/java/androidx/media3/test/utils/FakeExoMediaDrm.java
@@ -411,6 +411,16 @@ public final class FakeExoMediaDrm implements ExoMediaDrm {
     return FakeCryptoConfig.TYPE;
   }
 
+  @Override
+  public void removeOfflineLicense(byte[] keySetId) {
+    // Do nothing
+  }
+
+  @Override
+  public List<byte[]> getOfflineLicenseKeySetIds() {
+    return null;
+  }
+
   // Methods to facilitate testing
 
   public int getReferenceCount() {


### PR DESCRIPTION
Changes
---
- Added `removeOfflineLicense(byte[])` and `getOfflineLicenseKeySetIds` and consumed them in their implementations

Background
---
- These APIs will help in addressing an increasing amount of `java.lang.IllegalArgumentException: Failed to restore keys: BAD_VALUE` which is our top playback error in our app
	- Based on our discussion with Widevine team and [this exoplayer issue](https://github.com/google/ExoPlayer/issues/11202#issuecomment-1708792594)
		- TL;DR: The failure occurs on startup if the user has 200+ offline licenses, we would like to add the functionality to remove offline licenses

**Note: Why we want these APIs in ExoMediaDrm and not in OfflineLicenseHelper**

- As per the issue above, we would like to access these 2 public APIs in MediaDrm that don’t exist in `OfflineLicenseHelper` or `ExoMediaDrm`
	- APIs interested in:
		- [MediaDrm#removeOfflineLicense()](https://developer.android.com/reference/android/media/MediaDrm#removeOfflineLicense(byte%5B%5D)): To remove offline license
		- [MediaDrm#getOfflineLicenseKeySetIds()](https://developer.android.com/reference/android/media/MediaDrm#getOfflineLicenseKeySetIds()): To see number of offline licenses on startup

	- We use `OfflineLicenseHelper` to download license for L1 and we don't interact with `ExoMediaDrm` directly. But for the alternate Widevine integration, we directly depend on `ExoMediaDrm` APIs to override and call CDM Native APIs.
	- We would like to have the functionality of removing offline licenses for both integration which would need access to above APIs in `ExoMediaDrm`.

Links
---
- https://github.com/androidx/media/issues/659